### PR TITLE
Allow compilation on ESP-IDF framework

### DIFF
--- a/src/miniz.c
+++ b/src/miniz.c
@@ -1509,7 +1509,10 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
       {
         mz_uint8 *p = r->m_tables[0].m_code_size; mz_uint i;
         r->m_table_sizes[0] = 288; r->m_table_sizes[1] = 32; TINFL_MEMSET(r->m_tables[1].m_code_size, 5, 32);
-        for ( i = 0; i <= 143; ++i) *p++ = 8; for ( ; i <= 255; ++i) *p++ = 9; for ( ; i <= 279; ++i) *p++ = 7; for ( ; i <= 287; ++i) *p++ = 8;
+        for ( i = 0; i <= 143; ++i) *p++ = 8;
+	for ( ; i <= 255; ++i) *p++ = 9;
+	for ( ; i <= 279; ++i) *p++ = 7;
+	for ( ; i <= 287; ++i) *p++ = 8;
       }
       else
       {


### PR DESCRIPTION
When trying to use the library on the ESP IDF framework, an error is thrown because of the formatting of some successive for loops.

Moving those into separate lines solves the issue and allows ESP IDF to compile.

This was mentioned on #1, but the issue was closed because of a side discussion.