### PR TITLE
Add PNGLE_T_SIZE const so consumers of this library can allocate the memory

### DIFF
--- a/src/pngle.c
+++ b/src/pngle.c
@@ -121,6 +121,8 @@ struct _pngle_t {
 	uint8_t lz_buf[TINFL_LZ_DICT_SIZE]; // 32768 bytes
 };
 
+const size_t PNGLE_T_SIZE = sizeof(pngle_t);
+
 // magic
 static const uint8_t png_sig[] = { 137, 80, 78, 71, 13, 10, 26, 10 };
 static uint32_t interlace_off_x[8] = { 0,  0, 4, 0, 2, 0, 1, 0 };

--- a/src/pngle.h
+++ b/src/pngle.h
@@ -34,6 +34,8 @@ extern "C" {
 // Main Pngle object
 typedef struct _pngle_t pngle_t;
 
+extern const size_t PNGLE_T_SIZE;  // size of pngle_t structure
+
 // Callback signatures
 typedef void (*pngle_init_callback_t)(pngle_t *pngle, uint32_t w, uint32_t h);
 typedef void (*pngle_draw_callback_t)(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4]);


### PR DESCRIPTION
This allows ESPHome to use its own internal allocator to allocate the correct amount of memory.

Value is being reported as `43888`

- https://github.com/esphome/esphome/pull/8354